### PR TITLE
R21.0 token control

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+    "env": {
+        "commonjs": true,
+        "es2021": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,108 @@
 {
   "name": "teton-thor",
-  "version": "20.2.4",
+  "version": "21.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.13.10.tgz",
+      "integrity": "sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@babel/parser": {
       "version": "7.12.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
       "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==",
       "dev": true
     },
+    "@eslint/eslintrc": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
+      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
     },
     "ansi-colors": {
       "version": "4.1.1",
@@ -84,6 +172,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "atob": {
@@ -232,6 +326,22 @@
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -448,6 +558,12 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -501,6 +617,15 @@
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -522,6 +647,15 @@
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
         "tapable": "^1.0.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
       }
     },
     "entities": {
@@ -549,6 +683,293 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true
+    },
+    "eslint": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.23.0.tgz",
+      "integrity": "sha512-kqvNVbdkjzpFy0XOszNwjkKzZ+6TcwCQ/h+ozlcIWwaimBBuhlQ4nN6kbiM2L+OjDcznkTJxzYfRFH92sx4a0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.4.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.21",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-google": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
     "expand-brackets": {
@@ -690,6 +1111,33 @@
         }
       }
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -740,6 +1188,22 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
     },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -768,11 +1232,34 @@
       "dev": true,
       "optional": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -838,6 +1325,23 @@
         "which": "^1.2.14"
       }
     },
+    "globals": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.7.0.tgz",
+      "integrity": "sha512-Aipsz6ZKRxa/xQkZhNg0qIWXT6x6rD46f6x/PCnBomlttdIyAPak4YD9jTmKpZ72uROSMU87qJtcgpgHaVchiA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -849,10 +1353,25 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
     },
     "has-value": {
@@ -900,6 +1419,30 @@
       "dev": true,
       "requires": {
         "parse-passwd": "^1.0.0"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "import-local": {
@@ -972,6 +1515,15 @@
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -1066,6 +1618,12 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
     "is-plain-obj": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
@@ -1080,6 +1638,12 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -1103,6 +1667,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -1153,6 +1723,18 @@
         "underscore": "~1.10.2"
       }
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -1183,6 +1765,16 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.9"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "linkify-it": {
@@ -1219,6 +1811,24 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
       "dev": true
     },
     "log-symbols": {
@@ -1279,6 +1889,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "map-cache": {
@@ -1650,6 +2269,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -1728,6 +2353,20 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -1751,6 +2390,15 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -1803,16 +2451,34 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
     "randombytes": {
@@ -1858,6 +2524,12 @@
         "safe-regex": "^1.1.0"
       }
     },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
+    },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
@@ -1874,6 +2546,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -1940,6 +2618,15 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -2014,6 +2701,49 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
+      }
     },
     "slide": {
       "version": "1.1.6",
@@ -2241,6 +2971,81 @@
         "has-flag": "^3.0.0"
       }
     },
+    "table": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
+      "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.1.tgz",
+          "integrity": "sha512-46ZA4TalFcLLqX1dEU3dhdY38wAtDydJ4e7QQTVekLUTzXkb1LfqU6VOBXC/a9wiv4T094WURqJH6ZitF92Kqw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "taffydb": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
@@ -2251,6 +3056,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "to-object-path": {
@@ -2294,6 +3105,21 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -2357,6 +3183,15 @@
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         }
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
       }
     },
     "urix": {
@@ -2464,6 +3299,12 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "workerpool": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
@@ -2512,6 +3353,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {
+    "eslint": "^7.23.0",
+    "eslint-config-google": "^0.14.0",
     "jsdoc": "^3.6.6",
     "mocha": "^8.3.0",
     "webpack-cli": "^3.2.3"

--- a/src/api.js
+++ b/src/api.js
@@ -4,11 +4,6 @@ if (typeof window === 'undefined') {
 
   var os = require('os');
   var path = require('path');
-
-  var location = path.join(os.homedir(), '.thor');
-
-  var LocalStorage = require('node-localstorage').LocalStorage;
-  localStorage = new LocalStorage(location);
 }
 
 const _HelperCallbacks = {
@@ -19,8 +14,6 @@ const _HelperCallbacks = {
       } else {
         api.token = this.token;
         api.user = this.user;
-
-        localStorage.setItem('token', JSON.stringify(api.token));
 
         if (success !== undefined) {
           success.bind(api.user)();
@@ -55,34 +48,34 @@ class Message {
  * Handles Thor API requests
  */
 class API {
+  /**@typedef Token
+   * @property {string} expires - Token expiration date
+   * @property {string} id - Token id
+   */
+
   /**
    * API Constructor
    * @param {Object} [config] API configuration
    * @param {string} config.host=https://api.smartslice.xyz API protocol and host name
+   * @param {Token} config.token - Token object containing key and expiration
    */
   constructor(config) {
     if (config === undefined) {
       config = {
-        host: 'https://api.smartslice.xyz'
+        host: 'https://api.smartslice.xyz',
+        token: null
       };
     }
 
     this.host = config.host;
-    this.error = function() {};
+    this.token = config.token;
 
+    this.error = function() {};
     this.user = null;
-    this.token = null;
   }
 
   static get version() {
     return (typeof THOR_VERSION === 'undefined' ? '21.0' : THOR_VERSION);
-  }
-
-  /**
-   * @returns The LocalStorage object used by the API
-   */
-  static get localStorage() {
-    return localStorage;
   }
 
   get config() {
@@ -142,7 +135,7 @@ class API {
 
     xhttp.setRequestHeader('Accept-version', API.version);
 
-    if (this.token !== null) {
+    if (this.token) {
       xhttp.setRequestHeader('Authorization', 'Bearer ' + this.token.id);
     }
 
@@ -216,17 +209,9 @@ class API {
     let getUserInfoFromServer = false;
 
     if (this.token === null) {
-      // Check local storage for a token
-      let saved_token = localStorage.getItem('token');
-
-      if (saved_token === null || saved_token === undefined) {
-        error.bind(new Message(401, 'No token available'))();
-        return false;
-      }
-
-      this.token = JSON.parse(saved_token);
-
       getUserInfoFromServer = true;
+      error.bind(new Message(401, 'No token available'))();
+      return false;
     }
 
     if (this.user === null || getUserInfoFromServer) {
@@ -282,6 +267,14 @@ class API {
   }
 
   /**
+   *
+   * @param {Token} token
+   */
+  setToken(token) {
+    this.token = token
+  }
+
+  /**
    * Refreshes the API token. This is not usable for expired tokens. If a refresh
    * is attempted on an expired token the server will return 401 Unauthorized.
    * @param {API~getToken-success} success Callback function if refresh is successful.
@@ -313,7 +306,6 @@ class API {
             success();
           }
 
-          localStorage.removeItem('token');
         } else {
           if (error !== undefined) {
             error.bind(new Message(400, 'Failed to logout'));

--- a/src/api.js
+++ b/src/api.js
@@ -2,8 +2,8 @@
 if (typeof window === 'undefined') {
   XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 
-  var os = require('os');
-  var path = require('path');
+  const os = require('os');
+  const path = require('path');
 }
 
 const _HelperCallbacks = {
@@ -19,7 +19,7 @@ const _HelperCallbacks = {
           success.bind(api.user)();
         }
       }
-    }
+    };
   }
 };
 
@@ -48,7 +48,7 @@ class Message {
  * Handles Thor API requests
  */
 class API {
-  /**@typedef Token
+  /** @typedef Token
    * @property {string} expires - Token expiration date
    * @property {string} id - Token id
    */
@@ -81,17 +81,17 @@ class API {
   get config() {
     return {
       host: this.host
-    }
+    };
   }
 
   _request(method, route, success, error, data) {
-    var xhttp = new XMLHttpRequest();
+    const xhttp = new XMLHttpRequest();
 
     xhttp.onreadystatechange = function() {
       if (xhttp.readyState === 4) {
         try {
           var response = JSON.parse(xhttp.responseText);
-        } catch(err) {
+        } catch (err) {
           var response = xhttp.responseText;
         }
 
@@ -129,7 +129,7 @@ class API {
           error.bind(err)();
         }
       }
-    }
+    };
 
     xhttp.open(method, this.host + route, true);
 
@@ -165,7 +165,7 @@ class API {
    * @this {Message}
    */
 
-   /**
+  /**
     * Verify version successfull callback
     * @callback API~verify-version
     * @param {boolean} compatible True if the host version is compatible with this client library
@@ -179,33 +179,33 @@ class API {
   * @param {API~error} error
   */
   verifyVersion(success, error) {
-    let parseVersion = function() {
-      let sv = this.version.split('.');
-      let cv = API.version.split('.');
+    const parseVersion = function() {
+      const sv = this.version.split('.');
+      const cv = API.version.split('.');
 
-      let sv_maj = parseInt(sv[0]);
-      let sv_min = parseInt(sv[1]);
+      const sv_maj = parseInt(sv[0]);
+      const sv_min = parseInt(sv[1]);
 
-      let cv_maj = parseInt(cv[0]);
-      let cv_min = parseInt(cv[1]);
+      const cv_maj = parseInt(cv[0]);
+      const cv_min = parseInt(cv[1]);
 
       // Require the exact same version. As versions advance
       // how can we make this less restrictive?
-      let compatible = (sv_maj === cv_maj && sv_min === cv_min);
+      const compatible = (sv_maj === cv_maj && sv_min === cv_min);
 
       success(compatible, API.version, this.version);
-    }
+    };
 
     this._request('GET', '/', parseVersion, error);
   }
 
-   /**
+  /**
     * Checks if a token is already in use and
     * returns the user information if available, otherwise null
     * @param {API~getToken-success} success
     * @param {API~error} error
     */
-   whoAmI(success, error) {
+  whoAmI(success, error) {
     let getUserInfoFromServer = false;
 
     if (this.token === null) {
@@ -215,13 +215,13 @@ class API {
     }
 
     if (this.user === null || getUserInfoFromServer) {
-      let api = this;
+      const api = this;
 
-      let clearUser = function() {
+      const clearUser = function() {
         api.user = null;
         api.token = null;
         error.bind(this)();
-      }
+      };
 
       this._request('GET', '/auth/whoami', _HelperCallbacks.getToken(api, success, error), clearUser);
     } else {
@@ -233,14 +233,14 @@ class API {
 
   register(first_name, last_name, email, password, company, country, success, error) {
     this._request('POST', '/auth/register', success, error,
-      {
-        email: email,
-        first_name: first_name,
-        last_name: last_name,
-        password: password,
-        company: company,
-        country: country
-      }
+        {
+          email: email,
+          first_name: first_name,
+          last_name: last_name,
+          password: password,
+          company: company,
+          country: country
+        }
     );
   }
 
@@ -263,7 +263,7 @@ class API {
    */
   getToken(email, password, success, error) {
     this._request('POST', '/auth/token', _HelperCallbacks.getToken(this, success, error),
-      error, { email: email, password: password });
+        error, { email: email, password: password });
   }
 
   /**
@@ -271,7 +271,7 @@ class API {
    * @param {Token} token
    */
   setToken(token) {
-    this.token = token
+    this.token = token;
   }
 
   /**
@@ -295,24 +295,23 @@ class API {
    * @param {API~error} error
    */
   releaseToken(success, error) {
-    var api = this;
+    const api = this;
 
     this._request('DELETE', '/auth/token',
-      function() {
-        if (this.success) {
-          api.token = null;
-          api.user = null;
-          if (success !== undefined) {
-            success();
+        function() {
+          if (this.success) {
+            api.token = null;
+            api.user = null;
+            if (success !== undefined) {
+              success();
+            }
+          } else {
+            if (error !== undefined) {
+              error.bind(new Message(400, 'Failed to logout'));
+            }
           }
-
-        } else {
-          if (error !== undefined) {
-            error.bind(new Message(400, 'Failed to logout'));
-          }
-        }
-      },
-      error
+        },
+        error
     );
   }
 
@@ -324,10 +323,10 @@ class API {
    */
   verifyEmail(code, success, error) {
     this._request(
-      'POST', '/auth/verify',
-      success,
-      error,
-      { code: code }
+        'POST', '/auth/verify',
+        success,
+        error,
+        { code: code }
     );
   }
 
@@ -338,10 +337,10 @@ class API {
    */
   verifyEmailResend(email, success, error) {
     this._request(
-      'POST', '/auth/verify/resend',
-      success,
-      error,
-      { email: email }
+        'POST', '/auth/verify/resend',
+        success,
+        error,
+        { email: email }
     );
   }
 
@@ -354,14 +353,14 @@ class API {
    */
   changePassword(oldPassword, newPassword, success, error) {
     this._request(
-      'POST', '/auth/password/change',
-      success,
-      error,
-      {
-        old_password: oldPassword,
-        password: newPassword,
-        confirm_password: newPassword
-      }
+        'POST', '/auth/password/change',
+        success,
+        error,
+        {
+          old_password: oldPassword,
+          password: newPassword,
+          confirm_password: newPassword
+        }
     );
   }
 
@@ -373,10 +372,10 @@ class API {
    */
   forgotPassword(email, success, error) {
     this._request(
-      'POST', '/auth/password/forgot',
-      success,
-      error,
-      { email: email }
+        'POST', '/auth/password/forgot',
+        success,
+        error,
+        { email: email }
     );
   }
 
@@ -390,15 +389,15 @@ class API {
    */
   resetPassword(code, email, password, success, error) {
     this._request(
-      'POST', '/auth/password/reset',
-      success,
-      error,
-      {
-        email: email,
-        code: code,
-        password: password,
-        confirm_password: password
-      }
+        'POST', '/auth/password/reset',
+        success,
+        error,
+        {
+          email: email,
+          code: code,
+          password: password,
+          confirm_password: password
+        }
     );
   }
 
@@ -428,9 +427,9 @@ class API {
     }
 
     this._request(
-      'GET', url,
-      success,
-      error
+        'GET', url,
+        success,
+        error
     );
   }
 
@@ -473,10 +472,10 @@ class API {
    */
   submitSmartSliceJob(job, success, error) {
     this._request(
-      'POST', '/smartslice',
-      success,
-      error,
-      job
+        'POST', '/smartslice',
+        success,
+        error,
+        job
     );
   }
 
@@ -488,9 +487,9 @@ class API {
    */
   cancelSmartSliceJob(jobId, success, error) {
     this._request(
-      'DELETE', `/smartslice/${jobId}`,
-      success,
-      error
+        'DELETE', `/smartslice/${jobId}`,
+        success,
+        error
     );
   }
 
@@ -520,7 +519,7 @@ class API {
    * @param {API~job-poll-callback} poll
    */
   pollSmartSliceJob(jobId, error, finished, failed, poll) {
-    let api = this;
+    const api = this;
     const pollAgainStatuses = ['idle', 'queued', 'running'];
     const finishedStatuses = ['finished', 'aborted'];
 
@@ -529,10 +528,10 @@ class API {
 
     function pollJob(period) {
       return function() {
-        let handleJobStatus = function() {
+        const handleJobStatus = function() {
           if (pollAgainStatuses.includes(this.status)) {
             if (poll !== undefined) {
-              let abort = poll.bind(this)();
+              const abort = poll.bind(this)();
 
               if (abort) {
                 api.cancelSmartSliceJob(jobId, () => {}, () => {});
@@ -549,17 +548,17 @@ class API {
           }
         };
 
-        let errorHandler = function() {
+        const errorHandler = function() {
           if (this.http_code == 429) {
             // If the error is a rate limit, then just continue polling.
             setTimeout(pollJob(period), period);
           } else {
             error.bind(this)();
           }
-        }
+        };
 
         api.getSmartSliceJob(jobId, handleJobStatus, errorHandler, true);
-      }
+      };
     }
 
     pollJob(1000)();
@@ -575,13 +574,13 @@ class API {
    * @param {API~job-poll-callback} poll
    */
   submitSmartSliceJobAndPoll(job, error, finished, failed, poll) {
-    let that = this;
+    const that = this;
     this.submitSmartSliceJob(
-      job,
-      function() {
-        that.pollSmartSliceJob(this.id, error, finished, failed, poll);
-      },
-      error
+        job,
+        function() {
+          that.pollSmartSliceJob(this.id, error, finished, failed, poll);
+        },
+        error
     );
   }
 
@@ -593,7 +592,7 @@ class API {
    * @param {API~error} error
    */
   listSmartSliceJobs(limit, page, success, error) {
-    let route = `/smartslice/jobs?limit=${limit}&page=${page}`;
+    const route = `/smartslice/jobs?limit=${limit}&page=${page}`;
 
     this._request('GET', route, success, error);
   }
@@ -646,13 +645,13 @@ class API {
    */
   createTeam(name, fullName, success, error) {
     this._request(
-      'POST', '/teams',
-      success,
-      error,
-      {
-        name: name,
-        full_name: fullName
-      }
+        'POST', '/teams',
+        success,
+        error,
+        {
+          name: name,
+          full_name: fullName
+        }
     );
   }
 
@@ -728,13 +727,13 @@ class API {
    */
   addTeamMemberRole(team, email, role, success, error) {
     this._request(
-      'POST', `/teams/${team}/role`,
-      success,
-      error,
-      {
-        email: email,
-        role: role
-      }
+        'POST', `/teams/${team}/role`,
+        success,
+        error,
+        {
+          email: email,
+          role: role
+        }
     );
   }
 
@@ -748,13 +747,13 @@ class API {
    */
   revokeTeamMemberRole(team, email, role, success, error) {
     this._request(
-      'DELETE', `/teams/${team}/role`,
-      success,
-      error,
-      {
-        email: email,
-        role: role
-      }
+        'DELETE', `/teams/${team}/role`,
+        success,
+        error,
+        {
+          email: email,
+          role: role
+        }
     );
   }
 
@@ -781,13 +780,13 @@ class API {
     }
 
     this._request(
-      'POST', '/support/issue',
-      success,
-      error,
-      {
-        description: description,
-        job: jobId
-      }
+        'POST', '/support/issue',
+        success,
+        error,
+        {
+          description: description,
+          job: jobId
+        }
     );
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,13 +24,13 @@ let config = {
   token: null
 };
 
-let jconfig = storage.getItem('config');
+const jconfig = storage.getItem('config');
 
 if (jconfig !== null) {
   config = JSON.parse(jconfig);
 }
 
-let api = new thor.API(config);
+const api = new thor.API(config);
 
 const mutableStdout = new Writable({
   write: function(chunk, encoding, callback) {
@@ -152,7 +152,6 @@ teams
 app.parse(process.argv);
 
 function configure() {
-
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
@@ -162,29 +161,28 @@ function configure() {
   console.log('Leave inputs empty to use the default, specified in parentheses.');
   console.log('If you were previously logged in, this process will log you out.');
 
-  let new_config = {
+  const new_config = {
     host: HOST,
     token: null
   };
 
   rl.question('Host (' + HOST + '): ',
-    function(host) {
+      function(host) {
+        if (host.length > 0) {
+          new_config.host = host;
+        }
 
-      if (host.length > 0) {
-        new_config.host = host;
+        storage.setItem('config', JSON.stringify(new_config));
+
+        rl.close();
       }
-
-      storage.setItem('config', JSON.stringify(new_config));
-
-      rl.close();
-    }
   );
 
   api.releaseToken(function() {}, function() {});
 }
 
 function _multipleQuestions(questions, callback) {
-  let answers = [];
+  const answers = [];
 
   const rl = readline.createInterface({
     input: process.stdin,
@@ -193,16 +191,16 @@ function _multipleQuestions(questions, callback) {
 
   function askQuestion(i) {
     rl.question(
-      questions[i],
-      answer => {
-        answers.push(answer);
-        if (questions.length > (i + 1)) {
-          askQuestion(i + 1);
-        } else {
-          rl.close();
-          callback(...answers);
+        questions[i],
+        answer => {
+          answers.push(answer);
+          if (questions.length > (i + 1)) {
+            askQuestion(i + 1);
+          } else {
+            rl.close();
+            callback(...answers);
+          }
         }
-      }
     );
   }
 
@@ -219,19 +217,19 @@ function _getCredentials(callback) {
   mutableStdout.muted = false;
 
   rl.question('Email: ',
-    function(email) {
-      process.stdout.write('Password: ');
+      function(email) {
+        process.stdout.write('Password: ');
 
-      mutableStdout.muted = true;
+        mutableStdout.muted = true;
 
-      rl.question('',
-        function(pass) {
-          console.log('');
-          callback(email, pass);
-          rl.close();
-        }
-      );
-    }
+        rl.question('',
+            function(pass) {
+              console.log('');
+              callback(email, pass);
+              rl.close();
+            }
+        );
+      }
   );
 }
 
@@ -244,248 +242,247 @@ function _basicErrorCallback() {
 }
 
 function login() {
-  var loginWithCreds = function(email, pass) {
+  const loginWithCreds = function(email, pass) {
     api.getToken(email, pass,
-      function() {
-        const new_config = {
-          host: api.config.host,
-          token: api.token
-        }
-        storage.setItem('config', JSON.stringify(new_config));
-        console.log('Hi ' + this.first_name + ', you are logged in.');
-        console.log('Use the logout command to log out.');
-      },
-      _basicErrorCallback
+        function() {
+          const new_config = {
+            host: api.config.host,
+            token: api.token
+          };
+          storage.setItem('config', JSON.stringify(new_config));
+          console.log('Hi ' + this.first_name + ', you are logged in.');
+          console.log('Use the logout command to log out.');
+        },
+        _basicErrorCallback
     );
-  }
+  };
 
   _getCredentials(loginWithCreds);
 }
 
 function whoAmI(callback, ...args) {
   api.whoAmI(
-    _ => callback(...args),
-    function() {
-      console.error('No user is currently logged in');
-    }
+      _ => callback(...args),
+      function() {
+        console.error('No user is currently logged in');
+      }
   );
 }
 
 function logout() {
   whoAmI(
-    function() {
-      api.releaseToken(
-        function() { console.log('Logged out'); },
-        _basicErrorCallback
-      );
-    }
+      function() {
+        api.releaseToken(
+            function() { console.log('Logged out'); },
+            _basicErrorCallback
+        );
+      }
   );
 }
 
 function register() {
-  var first_name;
-  var last_name;
-  var country;
-  var company;
+  let first_name;
+  let last_name;
+  let country;
+  let company;
 
   const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout
   });
 
-  var registerWithCreds = function(email, pass) {
+  const registerWithCreds = function(email, pass) {
     api.register(
-      first_name, last_name, email, pass, company, country,
-      _basicSuccessCallback,
-      function() {
-        console.error('Failed to register');
-        console.error(this.message);
-        rl.close();
-      }
-    );
-  }
-
-  var countryAsk = function() {
-    rl.question(
-      'Country: ',
-      function(answer) {
-        country = answer;
-        rl.close();
-        _getCredentials(registerWithCreds);
-      }
+        first_name, last_name, email, pass, company, country,
+        _basicSuccessCallback,
+        function() {
+          console.error('Failed to register');
+          console.error(this.message);
+          rl.close();
+        }
     );
   };
 
-  var companyAsk = function() {
+  const countryAsk = function() {
     rl.question(
-      'Company: ',
-      function(answer) {
-        company = answer;
-        countryAsk();
-      }
+        'Country: ',
+        function(answer) {
+          country = answer;
+          rl.close();
+          _getCredentials(registerWithCreds);
+        }
     );
   };
 
-  var lastNameAsk = function() {
+  const companyAsk = function() {
     rl.question(
-      'Last Name: ',
-      function(answer) {
-        last_name = answer;
-        companyAsk();
-      }
+        'Company: ',
+        function(answer) {
+          company = answer;
+          countryAsk();
+        }
+    );
+  };
+
+  const lastNameAsk = function() {
+    rl.question(
+        'Last Name: ',
+        function(answer) {
+          last_name = answer;
+          companyAsk();
+        }
     );
   };
 
   rl.question(
-    'First Name: ',
-    function(answer) {
-      first_name = answer;
-      lastNameAsk();
-    }
+      'First Name: ',
+      function(answer) {
+        first_name = answer;
+        lastNameAsk();
+      }
   );
 }
 
 function verifyEmail() {
   if (this.resend !== undefined) {
     api.verifyEmailResend(
-      this.resend,
-      _basicSuccessCallback,
-      _basicErrorCallback
+        this.resend,
+        _basicSuccessCallback,
+        _basicErrorCallback
     );
   } else {
     api.verifyEmail(
-      this.code,
-      _basicSuccessCallback,
-      _basicErrorCallback
+        this.code,
+        _basicSuccessCallback,
+        _basicErrorCallback
     );
   }
 }
 
 function changePassword() {
   whoAmI(
-    function() {
-      const rl = readline.createInterface({
-        input: process.stdin,
-        output: mutableStdout,
-        terminal: true
-      });
+      function() {
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: mutableStdout,
+          terminal: true
+        });
 
-      mutableStdout.muted = true;
+        mutableStdout.muted = true;
 
-      process.stdout.write('Old Password: ');
+        process.stdout.write('Old Password: ');
 
-      rl.question('',
-        function(oldPassword) {
-          process.stdout.write('\nNew Password: ');
+        rl.question('',
+            function(oldPassword) {
+              process.stdout.write('\nNew Password: ');
 
-          rl.question('',
-            function(newPassword) {
-              console.log('');
-              api.changePassword(
-                oldPassword,
-                newPassword,
-                function() {
-                  console.log(this.message);
-                  console.log('You will need to log back in.');
-                },
-                _basicErrorCallback
+              rl.question('',
+                  function(newPassword) {
+                    console.log('');
+                    api.changePassword(
+                        oldPassword,
+                        newPassword,
+                        function() {
+                          console.log(this.message);
+                          console.log('You will need to log back in.');
+                        },
+                        _basicErrorCallback
+                    );
+
+                    rl.close();
+                  }
               );
-
-              rl.close();
             }
-          );
-        }
-      );
-    }
+        );
+      }
   );
 }
 
 function forgotPassword() {
   api.forgotPassword(
-    this.email,
-    _basicSuccessCallback,
-    _basicErrorCallback
+      this.email,
+      _basicSuccessCallback,
+      _basicErrorCallback
   );
 }
 
 function resetPassword() {
-  let code = this.code;
+  const code = this.code;
 
   _getCredentials(
-    function(email, password) {
-      api.resetPassword(
-        code,
-        email,
-        password,
-        _basicSuccessCallback,
-        _basicErrorCallback
-      )
-    }
+      function(email, password) {
+        api.resetPassword(
+            code,
+            email,
+            password,
+            _basicSuccessCallback,
+            _basicErrorCallback
+        );
+      }
   );
 }
 
 function submitSmartSliceJob(job, is3mf) {
   const outputFile = path.join(
-    path.dirname(job),
-    path.basename(job).slice(0, job.lastIndexOf('.')) + '.out.json'
+      path.dirname(job),
+      path.basename(job).slice(0, job.lastIndexOf('.')) + '.out.json'
   );
 
   fs.readFile(
-    job,
-    (error, data) => {
-      if (error) {
-        console.error(error);
-      } else {
-
-        if (!is3mf) {
-          try {
-            data = JSON.parse(data);
-          } catch (error) {
-            throw new Error('JSON failed to parse. If this is a 3MF file use the submit3MF command');
+      job,
+      (error, data) => {
+        if (error) {
+          console.error(error);
+        } else {
+          if (!is3mf) {
+            try {
+              data = JSON.parse(data);
+            } catch (error) {
+              throw new Error('JSON failed to parse. If this is a 3MF file use the submit3MF command');
+            }
           }
+
+          console.log('CTRL+C to cancel job');
+
+          let abort = false;
+
+          process.on('SIGINT', _ => {
+            abort = true;
+          });
+
+          api.submitSmartSliceJobAndPoll(
+              data,
+              function() { console.error(this); },
+              function() {
+                if (this.status === 'finished') {
+                  console.log(`Job finished, writing result to ${outputFile}`);
+                  fs.writeFileSync(outputFile, JSON.stringify(this.result));
+                } else {
+                  console.log(`Job ${this.status}`);
+                }
+              },
+              function() {
+                console.error('Job failed');
+                for (const e of this.errors) {
+                  console.error(e);
+                }
+              },
+              function() {
+                const now = new Date();
+                console.debug(`${now.toLocaleTimeString()} - Job ${this.id}: ${this.status} (${this.progress})`);
+                return abort;
+              }
+          );
         }
-
-        console.log('CTRL+C to cancel job');
-
-        let abort = false;
-
-        process.on('SIGINT', _ => {
-          abort = true;
-        });
-
-        api.submitSmartSliceJobAndPoll(
-          data,
-          function() { console.error(this); },
-          function() {
-            if (this.status === 'finished') {
-              console.log(`Job finished, writing result to ${outputFile}`);
-              fs.writeFileSync(outputFile, JSON.stringify(this.result));
-            } else {
-              console.log(`Job ${this.status}`);
-            }
-          },
-          function() {
-            console.error('Job failed');
-            for (let e of this.errors) {
-              console.error(e);
-            }
-          },
-          function() {
-            let now = new Date();
-            console.debug(`${now.toLocaleTimeString()} - Job ${this.id}: ${this.status} (${this.progress})`);
-            return abort;
-          }
-        )
       }
-    }
   );
 }
 
 function cancelSmartSliceJob(jobId) {
   api.cancelSmartSliceJob(
-    jobId,
-    function() { console.log(`Job status: ${this.status}`); },
-    _basicErrorCallback
+      jobId,
+      function() { console.log(`Job status: ${this.status}`); },
+      _basicErrorCallback
   );
 }
 
@@ -497,43 +494,43 @@ function listSmartSliceJobs(page, limit) {
   page = Math.max(1, page);
   limit = Math.max(1, limit);
 
-  let success = function() {
+  const success = function() {
     console.log(`Page ${this.page}/${this.total_pages}`);
-    for (let job of this.jobs) {
+    for (const job of this.jobs) {
       console.log(`${job.id} : ${job.status} (${job.progress})`);
     }
     console.log(`Page ${this.page}/${this.total_pages}`);
-  }
+  };
 
   api.listSmartSliceJobs(limit, page, success, _basicErrorCallback);
 }
 
 function createTeam() {
   _multipleQuestions(
-    ['Team Name (lowercase a-z, 0-9, "_", and "-" only, 3-64 characters): ', 'Full Team Name: '],
-    function(name, fullName) {
-      api.createTeam(
-        name,
-        fullName,
-        _basicSuccessCallback,
-        _basicErrorCallback
-      );
-    }
+      ['Team Name (lowercase a-z, 0-9, "_", and "-" only, 3-64 characters): ', 'Full Team Name: '],
+      function(name, fullName) {
+        api.createTeam(
+            name,
+            fullName,
+            _basicSuccessCallback,
+            _basicErrorCallback
+        );
+      }
   );
 }
 
 function listMemberships() {
   api.teamMemberships(
-    function() { console.log(this); },
-    _basicErrorCallback
+      function() { console.log(this); },
+      _basicErrorCallback
   );
 }
 
 function listTeamMembers(team) {
   api.teamMembers(
-    team,
-    function() { console.log(this); },
-    _basicErrorCallback
+      team,
+      function() { console.log(this); },
+      _basicErrorCallback
   );
 }
 
@@ -556,15 +553,15 @@ function removeTeamMember(team, email) {
   });
 
   rl.question(
-    `Are you sure you want to remove ${email} from ${team} (y/N): `,
-    answer => {
-      if (answer.length == 1 && answer.toLowerCase()[0] == 'y') {
-        api.removeTeamMember(team, email, _basicSuccessCallback, _basicErrorCallback);
-      } else {
-        console.log('Member removal action canceled');
+      `Are you sure you want to remove ${email} from ${team} (y/N): `,
+      answer => {
+        if (answer.length == 1 && answer.toLowerCase()[0] == 'y') {
+          api.removeTeamMember(team, email, _basicSuccessCallback, _basicErrorCallback);
+        } else {
+          console.log('Member removal action canceled');
+        }
+        rl.close();
       }
-      rl.close();
-    }
   );
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,16 +9,22 @@ const fs = require('fs');
 const path = require('path');
 const process = require('process');
 const readline = require('readline');
+const os = require('os');
 const Writable = require('stream').Writable;
 const thor = require('./thor');
+
+const location = path.join(os.homedir(), '.thor');
+const LocalStorage = require('node-localstorage').LocalStorage;
+const storage = new LocalStorage(location);
 
 // default configuration
 const HOST = 'https://api.smartslice.xyz';
 let config = {
-  host: HOST
+  host: HOST,
+  token: null
 };
 
-let jconfig = thor.API.localStorage.getItem('config');
+let jconfig = storage.getItem('config');
 
 if (jconfig !== null) {
   config = JSON.parse(jconfig);
@@ -147,7 +153,8 @@ function configure() {
   console.log('If you were previously logged in, this process will log you out.');
 
   let new_config = {
-    host: HOST
+    host: HOST,
+    token: null
   };
 
   rl.question('Host (' + HOST + '): ',
@@ -157,7 +164,7 @@ function configure() {
         new_config.host = host;
       }
 
-      thor.API.localStorage.setItem('config', JSON.stringify(new_config));
+      storage.setItem('config', JSON.stringify(new_config));
 
       rl.close();
     }
@@ -230,6 +237,11 @@ function login() {
   var loginWithCreds = function(email, pass) {
     api.getToken(email, pass,
       function() {
+        const new_config = {
+          host: api.config.host,
+          token: api.token
+        }
+        storage.setItem('config', JSON.stringify(new_config));
         console.log('Hi ' + this.first_name + ', you are logged in.');
         console.log('Use the logout command to log out.');
       },


### PR DESCRIPTION
Removes node local storage from api.js

I kept local storage in place for cli.js because I wasn't sure how else to store the token. Also I added an eslint file adopting the google style guide, The only difference between that and our current styling is that hanging indents are 4 spaces instead of 2, If we want to stay with 2 spaces for a hanging indent I can add a rule in the eslint file.