### PR TITLE
initial async switch

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -9,29 +9,16 @@ import {
   EncodingValues,
   HTTPMethod,
   Token,
+  Response
 } from './types';
+import { ServerResponse } from 'node:http';
+import { callbackify } from 'node:util';
 
 
 if (typeof window === 'undefined') {
   var XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 }
 
-const _HelperCallbacks = {
-  getToken: function(api: API, success: Callback.GetToken, error: Callback.Error) {
-    return function() {
-      if (this.error && error !== undefined) {
-        error.bind(this)();
-      } else {
-        api.token = this.token;
-        api.user = this.user;
-
-        if (success !== undefined) {
-          success.bind(this)();
-        }
-      }
-    };
-  },
-};
 
 
 class Message {
@@ -71,7 +58,7 @@ export class API {
   public id: string;
 
 
-  constructor(config?: {host: string, token: Token}) {
+  constructor(config?: { host: string, token: Token }) {
     if (config === undefined) {
       config = {
         host: 'https://api.smartslice.xyz',
@@ -96,309 +83,322 @@ export class API {
     };
   }
 
-  _request(method: HTTPMethod, route: string, success: Callback.Any, error: Callback.Error, data?, encoding?: Encoding) {
-    const xhttp = new XMLHttpRequest();
 
-    xhttp.onreadystatechange = function() {
-      let response;
-
-      if (xhttp.readyState === 4) {
-        try {
-          response = JSON.parse(xhttp.responseText);
-        } catch (err) {
-          response = xhttp.responseText;
-        }
-
-        if (xhttp.getResponseHeader(EncodingTypes.content) == EncodingValues.gzip) {
-          zlib.gunzip(response, (_, data) => {
-            response = JSON.parse(data.toString());
-          });
-        }
-
-        let err = null;
-
-        if (xhttp.status === 200 || xhttp.status === 202) {
-          if (success !== undefined) {
-            success.bind(response)();
+  /**
+   * 
+   * @returns Promise that resolves or rejects to a thor response
+   */
+  private _request(
+    method: HTTPMethod,
+    route: string,
+    data?,
+    encoding?: Encoding
+  ): Promise<Response.Any> {
+    return new Promise((resolve, reject) => {
+      const xhttp = new XMLHttpRequest();
+  
+      xhttp.onreadystatechange = function () {
+        let response;
+  
+        if (xhttp.readyState === 4) {
+          try {
+            response = JSON.parse(xhttp.responseText);
+          } catch (err) {
+            response = xhttp.responseText;
           }
-        } else if (xhttp.status === 401) {
-          err = new Message(xhttp.status, 'Unauthorized');
-        } else if (xhttp.status === 404) {
-          err = new Message(xhttp.status, 'Not Found');
-        } else if (xhttp.status === 500) {
-          err = new Message(xhttp.status, 'Internal server error');
-        } else {
-          let message = null;
-
-          if (typeof response === 'string') {
-            message = response;
+  
+          if (xhttp.getResponseHeader(EncodingTypes.content) == EncodingValues.gzip) {
+            zlib.gunzip(response, (_, data) => {
+              response = JSON.parse(data.toString());
+            });
+          }
+  
+          let err = null;
+          if (xhttp.status === 200 || xhttp.status === 202) {
+            resolve(response)
+          } else if (xhttp.status === 401) {
+            err = new Message(xhttp.status, 'Unauthorized');
+          } else if (xhttp.status === 404) {
+            err = new Message(xhttp.status, 'Not Found');
+          } else if (xhttp.status === 500) {
+            err = new Message(xhttp.status, 'Internal server error');
           } else {
-            if ('error' in response) {
-              message = response.error;
-            }
-
-            if (message === null) {
+            let message = null;
+  
+            if (typeof response === 'string') {
               message = response;
+            } else {
+              if ('error' in response) {
+                message = response.error;
+              }
+  
+              if (message === null) {
+                message = response;
+              }
             }
+  
+            err = new Message(xhttp.status, message);
           }
-
-          err = new Message(xhttp.status, message);
+  
+          if (err !== null) {
+            reject(err)
+          }
         }
-
-        if (err !== null && error !== undefined) {
-          error.bind(err)();
+      };
+  
+      xhttp.open(method, this.host + route, true);
+  
+      xhttp.setRequestHeader('Accept-version', API.version);
+  
+      if (encoding) {
+        xhttp.setRequestHeader(encoding.name, encoding.value);
+      }
+  
+      if (this.token) {
+        xhttp.setRequestHeader('Authorization', 'Bearer ' + this.token.id);
+      }
+  
+      if (method === 'GET' || data === undefined) {
+        xhttp.send();
+      } else if (data instanceof Buffer) {
+        xhttp.setRequestHeader('Content-Type', 'model/3mf');
+        if (encoding && encoding.value == EncodingValues.gzip) {
+          zlib.gzip(data, (_, gz) => {
+            xhttp.send(gz);
+          });
+        } else {
+          xhttp.send(data);
+        }
+      } else {
+        xhttp.setRequestHeader('Content-Type', 'application/json');
+        if (encoding && encoding.value == EncodingValues.gzip) {
+          zlib.gzip(JSON.stringify(data), (_, gz) => {
+            xhttp.send(gz);
+          });
+        } else {
+          xhttp.send(JSON.stringify(data));
         }
       }
-    };
-
-    xhttp.open(method, this.host + route, true);
-
-    xhttp.setRequestHeader('Accept-version', API.version);
-
-    if (encoding) {
-      xhttp.setRequestHeader(encoding.name, encoding.value);
-    }
-
-    if (this.token) {
-      xhttp.setRequestHeader('Authorization', 'Bearer ' + this.token.id);
-    }
-
-    if (method === 'GET' || data === undefined) {
-      xhttp.send();
-    } else if (data instanceof Buffer) {
-      xhttp.setRequestHeader('Content-Type', 'model/3mf');
-      if (encoding && encoding.value == EncodingValues.gzip) {
-        zlib.gzip(data, (_, gz) => {
-          xhttp.send(gz);
-        });
-      } else {
-        xhttp.send(data);
-      }
-    } else {
-      xhttp.setRequestHeader('Content-Type', 'application/json');
-      if (encoding && encoding.value == EncodingValues.gzip) {
-        zlib.gzip(JSON.stringify(data), (_, gz) => {
-          xhttp.send(gz);
-        });
-      } else {
-        xhttp.send(JSON.stringify(data));
-      }
-    }
+    })
   }
 
+  async verifyVersion() {
+    const sv = (await this._request(HTTPMethod.GET, '/') as Response.Version)
+      .version.split('.');
+    const cv = API.version.split('.');
 
-  verifyVersion(success: Callback.Version, error: Callback.Error) {
-    const parseVersion = function() {
-      const sv = this.version.split('.');
-      const cv = API.version.split('.');
+    const sv_maj = parseInt(sv[0]);
+    const sv_min = parseInt(sv[1]);
 
-      const sv_maj = parseInt(sv[0]);
-      const sv_min = parseInt(sv[1]);
+    const cv_maj = parseInt(cv[0]);
+    const cv_min = parseInt(cv[1]);
 
-      const cv_maj = parseInt(cv[0]);
-      const cv_min = parseInt(cv[1]);
-
-      // Require the exact same version. As versions advance
-      // how can we make this less restrictive?
-      const compatible = (sv_maj === cv_maj && sv_min === cv_min);
-
-      success(compatible, API.version, this.version);
-    };
-
-    this._request(HTTPMethod.GET, '/', parseVersion, error);
+    // Require the exact same version. As versions advance
+    // how can we make this less restrictive?
+    return (sv_maj === cv_maj && sv_min === cv_min);
   }
 
   /**
-    * Checks if a token is already in use and
-    * returns the user information if available, otherwise null
+    * @returns Promise that resolves to Response.GetToken and rejects to Response.Message
+    * @example
+    * ```ts
+    * async function whoAmI() {
+    *  let response = await api.whoAmI()
+    *    .catch((err: Response.Message) => {
+    *      console.log(err)
+    *    }) as Response.GetToken
+    *  console.log(response)
+    * }
+    * ```  
     */
-  whoAmI(success: Callback.GetToken, error: Callback.Error) {
-    let getUserInfoFromServer = false;
-
-    if (this.token === null) {
-      getUserInfoFromServer = true;
-
-      error.bind(new Message(401, 'No token available'))();
-      return false;
+  async whoAmI(): Promise<Response.GetToken | Message> {
+    const success = (response: Response.GetToken) => {
+      this.user = response.user
+      this.token = response.token
+      return response
     }
 
-    if (this.user === null || getUserInfoFromServer) {
-      const api = this;
-
-      const clearUser = function() {
-        api.user = null;
-        api.token = null;
-        error.bind(this)();
-      };
-
-      this._request(HTTPMethod.GET, '/auth/whoami', _HelperCallbacks.getToken(api, success, error), clearUser);
-    } else {
-      success.bind(this.user)();
+    const error = () => {
+      this.user = null
+      this.token = null
+      return new Message(401, 'No token available')
     }
 
-    return true;
+    return await this._request(HTTPMethod.GET, '/auth/whoami')
+      .then(success, error)
   }
 
-  register(
+  /**
+   * 
+    * @returns Promise that resolves to Response.Message and rejects to Response.Message
+   */
+  async register(
     first_name: string,
     last_name: string,
     email: string,
     password: string,
     company: string,
     country: string,
-    success: Callback.Success,
-    error: Callback.Error,
-  ) {
-    this._request(HTTPMethod.POST, '/auth/register', success, error,
-      {
-        email: email,
-        first_name: first_name,
-        last_name: last_name,
-        password: password,
-        company: company,
-        country: country,
-      },
-    );
+  ): Promise<Response.Message> {
+    const data =  {
+      email: email,
+      first_name: first_name,
+      last_name: last_name,
+      password: password,
+      company: company,
+      country: country,
+    }
+    
+    return await this._request(HTTPMethod.POST, '/auth/register', data) as Response.Message;
+  }
+  
+  /**
+   * 
+   * @returns Promise that resolves to Response.GetToken and rejects to  Response.Message
+   * @example
+   *
+   * ```ts
+   * async function getToken(email:string, pass: string) {
+   *  let response = await api.getToken(email, pass)
+   *    .catch((err: Response.Message) => {
+   *      console.log(err)
+   *     }) as Response.GetToken
+   *  console.log(response)
+   * }
+   * ```   
+   * */
+  async getToken(email: string, password: string): Promise<Response.GetToken | Response.Message>{
+    const success = (response: Response.GetToken) => {
+      this.token = response.token
+      this.user = response.user
+      return response
+    }
+
+    return await this._request(HTTPMethod.POST, '/auth/token', { email: email, password: password }).then(success)
   }
 
-  getToken(email: string, password: string, success: Callback.GetToken, error: Callback.Error) {
-    this._request(HTTPMethod.POST, '/auth/token', _HelperCallbacks.getToken(this, success, error),
-      error, {email: email, password: password});
-  }
 
   setToken(token: Token) {
     this.token = token;
   }
 
-  refreshToken(success: Callback.GetToken, error: Callback.Error) {
+  async refreshToken(): Promise<Response.GetToken | Response.Message> {
     if (this.token === null) {
-      error.call('null token');
       return;
     }
 
-    this._request(HTTPMethod.PUT, '/auth/token', _HelperCallbacks.getToken(this, success, error), error);
+    const success = (response: Response.GetToken) => {
+      return response
+    }
+
+    const error = (err: Response.Message) => {
+      return err
+    }
+
+    return await this._request(HTTPMethod.PUT, '/auth/token')
+      .then(success, error)
   }
 
   /**
    * Deletes the stored API token.
    */
-  releaseToken(success: Callback.Success, error: Callback.Error) {
-    const api = this;
-
-    this._request(HTTPMethod.DELETE, '/auth/token',
-      function() {
-        if (this.success) {
-          api.token = null;
-          api.user = null;
-          if (success !== undefined) {
-            success.call(this);
-          }
-        } else {
-          if (error !== undefined) {
-            error.bind(new Message(400, 'Failed to logout'));
-          }
-        }
-      },
-      error,
-    );
+  async releaseToken(): Promise<Response.Message> {
+    return await this._request(HTTPMethod.DELETE, '/auth/token') as Response.Message;
   }
 
-  verifyEmail(code: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
-      HTTPMethod.POST, '/auth/verify',
-      success,
-      error,
-      {code: code},
-    );
+  async verifyEmail(code: string): Promise<Response.Message> {
+    return await this._request(HTTPMethod.POST, '/auth/verify', {code: code}) as Response.Message;
   }
 
-  verifyEmailResend(email: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
-      HTTPMethod.POST, '/auth/verify/resend',
-      success,
-      error,
-      {email: email},
-    );
+  async verifyEmailResend(email: string): Promise<Response.Message> {
+    return await this._request(HTTPMethod.POST, '/auth/verify/resend', {email: email}) as Response.Message;
   }
 
-  changePassword(oldPassword: string, newPassword: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
+  async changePassword(oldPassword: string, newPassword: string): Promise<Response.Message> {
+    return await this._request(
       HTTPMethod.POST, '/auth/password/change',
-      success,
-      error,
       {
         old_password: oldPassword,
         password: newPassword,
         confirm_password: newPassword,
       },
-    );
+    ) as Response.Message;
   }
 
-  forgotPassword(email: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
-      HTTPMethod.POST, '/auth/password/forgot',
-      success,
-      error,
-      {email: email},
-    );
+  async forgotPassword(email: string): Promise<Response.Message> {
+    return await this._request(
+      HTTPMethod.POST,
+      '/auth/password/forgot',
+      { email: email }
+    ) as Response.Message;
   }
 
-  resetPassword(code: string, email: string, password: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
+  async resetPassword(code: string, email: string, password: string): Promise<Response.Message> {
+    return await this._request(
       HTTPMethod.POST, '/auth/password/reset',
-      success,
-      error,
       {
         email: email,
         code: code,
         password: password,
         confirm_password: password,
       },
-    );
+    ) as Response.Message;
   }
 
-  getSmartSliceSubscription(
-    success: Callback.Subscription,
-    error: Callback.Error,
-    team: string,
-  ) {
+  /**
+   * 
+   * @returns Promise that resolves to Response.Subscription and rejects to Response.Message
+   */
+  async getSmartSliceSubscription(team: string): Promise<Response.Subscription | Response.Message> {
     let url = '/smartslice/subscription';
 
     if (team) {
       url += `?team=${team}`;
     }
 
-    this._request(
-      HTTPMethod.GET, url,
-      success,
-      error,
-    );
+    const success = (response: Response.Subscription) => {
+      return response
+    }
+
+    const error = (response: Response.Message) => {
+      return response
+    }
+
+    return await this._request(HTTPMethod.GET, url)
+      .then(success, error);
   }
 
-  submitSmartSliceJob(job: JobData, success: Callback.Job, error: Callback.Error) {
+  /**
+   * @returns Promise that resolves to Response.Job and rejects to Response.Message
+   */
+  async submitSmartSliceJob(job: JobData): Promise<Response.Job | Response.Message> {
     const encoding: Encoding = {
       name: EncodingTypes.content,
       value: EncodingValues.gzip,
     };
 
-    this._request(
-      HTTPMethod.POST, '/smartslice',
-      success,
-      error,
-      job,
-      encoding,
-    );
+    const success = (response: Response.Job) => {
+      return response
+    }
+
+    const error = (response: Response.Message) => {
+      return response
+    }
+
+    return await this._request(
+      HTTPMethod.POST, '/smartslice', job, encoding,
+    ).then(success, error);
   }
 
-  cancelSmartSliceJob(jobId: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
-      HTTPMethod.DELETE, `/smartslice/${jobId}`,
-      success,
-      error,
-    );
+  async cancelSmartSliceJob(jobId: string): Promise<Response.Message> {
+    return await this._request(HTTPMethod.DELETE, `/smartslice/${jobId}`) as Response.Message;
   }
 
-  getSmartSliceJob(jobId: string, success: Callback.Job, error: Callback.Error, withResults: boolean) {
+  /**
+   * 
+   * @returns Promise that resolves to Response.Job and rejects to Response.Message 
+   */
+  async getSmartSliceJob(jobId: string, withResults: boolean): Promise<Response.Job | Response.Message> {
     let route = `/smartslice/${jobId}`;
     let encoding: Encoding;
 
@@ -410,14 +410,20 @@ export class API {
       };
     }
 
-    this._request(HTTPMethod.GET, route, success, error, encoding);
+    const success = (response: Response.Job) => {
+      return response
+    }
+
+    const error = (response: Response.Message) => {
+      return response
+    }
+
+    return await this._request(HTTPMethod.GET, route, null, encoding)
+      .then(success, error);
   }
 
-  pollSmartSliceJob(
+  async pollSmartSliceJob(
     jobId: string,
-    error: Callback.Error,
-    finished: Callback.Job,
-    failed: Callback.Job,
     poll: Callback.JobPoll,
   ) {
     const api: API = this;
@@ -427,80 +433,76 @@ export class API {
     const maxPeriod = 30000;
     const periodMultiplier = 1.25;
 
-    function pollJob(period) {
-      return function() {
-        const handleJobStatus = function() {
+    async function pollJob(period: number) {
+      return async function (response: Response.Job) {
+        const handleJobStatus = async function() {
           if (pollAgainStatuses.includes(this.status)) {
             if (poll !== undefined) {
               const abort = poll.bind(this)();
 
               if (abort) {
-                api.cancelSmartSliceJob(jobId, () => { }, () => { });
+                await api.cancelSmartSliceJob(jobId);
               }
             }
-
+            
             period = Math.min(maxPeriod, period * periodMultiplier);
 
-            setTimeout(pollJob(period), period);
-          } else if (finishedStatuses.includes(this.status)) {
-            finished.bind(this)();
+            setTimeout(await pollJob(period), period);
           } else {
-            failed.bind(this)();
+            return response
           }
         };
 
-        const errorHandler = function() {
+        const errorHandler = async function(response: Response.Message) {
           if (this.http_code == 429) {
             // If the error is a rate limit, then just continue polling.
-            setTimeout(pollJob(period), period);
+            setTimeout(await pollJob(period), period);
           } else {
-            error.bind(this)();
+            return response
           }
         };
 
-        api.getSmartSliceJob(jobId, handleJobStatus, errorHandler, true);
+        return await api.getSmartSliceJob(jobId, true)
+          .then(handleJobStatus, errorHandler);
       };
     }
 
-    pollJob(1000)();
+    return await pollJob(1000);
   }
 
-  submitSmartSliceJobAndPoll(
+  async submitSmartSliceJobAndPoll(
     job: JobData,
-    error: Callback.Error,
-    finished: Callback.Job,
-    failed: Callback.Job,
     poll: Callback.JobPoll,
   ) {
     const that = this;
-    this.submitSmartSliceJob(
-      job,
-      function() {
-        that.pollSmartSliceJob(this.id, error, finished, failed, poll);
-      },
-      error,
-    );
+
+    const success = async (response) => {
+      await that.pollSmartSliceJob(this.id, poll)
+    }
+
+    const error = (response) => {
+      return response
+    }
+    
+    return await this.submitSmartSliceJob(job)
+      .then(success, error);
   }
 
-  listSmartSliceJobs(
+  async listSmartSliceJobs(
     limit: number,
     page: number,
-    success: Callback.ListJob,
-    error: Callback.Error,
   ) {
     const route = `/smartslice/jobs?limit=${limit}&page=${page}`;
 
-    this._request(HTTPMethod.GET, route, success, error);
+    return await this._request(HTTPMethod.GET, route);
   }
 
   /**
    * Create a new team.
    */
-  createTeam(name: string, fullName: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
+  async createTeam(name: string, fullName: string) {
+    return await this._request(
       HTTPMethod.POST, '/teams',
-      success,
-      error,
       {
         name: name,
         full_name: fullName,
@@ -511,53 +513,51 @@ export class API {
   /**
    * Get a list of the teams the logged in user is a member of
    */
-  teamMemberships(success: Callback.Success, error: Callback.Error) {
-    this._request(HTTPMethod.GET, '/teams', success, error);
+  async teamMemberships() {
+    return await this._request(HTTPMethod.GET, '/teams');
   }
 
   /**
    * Get a list of the members for the given team.
    */
-  teamMembers(team: string, success: Callback.TeamMembers, error: Callback.Error) {
-    this._request(HTTPMethod.GET, `/teams/${team}/members`, success, error);
+  async teamMembers(team: string) {
+    return await this._request(HTTPMethod.GET, `/teams/${team}/members`);
   }
 
   /**
    * Invite a user to the given team, by email.
    */
-  inviteToTeam(team: string, email: string, success: Callback.Success, error: Callback.Error) {
-    this._request(HTTPMethod.POST, `/teams/${team}/invite`, success, error, {email: email});
+  async inviteToTeam(team: string, email: string) {
+    return await this._request(HTTPMethod.POST, `/teams/${team}/invite`, {email: email});
   }
 
   /**
    * Revoke an existing invitation to a user, by email. If the user has already accepted the invite, this will not remove them from the team.
    */
-  revokeTeamInvite(team: string, email: string, success: Callback.Success, error: Callback.Error) {
-    this._request(HTTPMethod.DELETE, `/teams/${team}/invite`, success, error, {email: email});
+  async revokeTeamInvite(team: string, email: string) {
+    return await this._request(HTTPMethod.DELETE, `/teams/${team}/invite`, {email: email});
   }
 
   /**
    * Accept an invite to the given team.
    */
-  acceptTeamInvite(team: string, success: Callback.Success, error: Callback.Error) {
-    this._request(HTTPMethod.GET, `/teams/${team}/invite`, success, error);
+  async acceptTeamInvite(team: string) {
+    return await this._request(HTTPMethod.GET, `/teams/${team}/invite`);
   }
 
   /**
    * Remove a user from the team and all of their roles.
    */
-  removeTeamMember(team: string, email: string, success: Callback.Success, error: Callback. Error) {
-    this._request(HTTPMethod.DELETE, `/teams/${team}/member`, success, error, {email: email});
+  async removeTeamMember(team: string, email: string) {
+    return await this._request(HTTPMethod.DELETE, `/teams/${team}/member`, {email: email});
   }
 
   /**
    * Add a role to a member of a given team.
    */
-  addTeamMemberRole(team: string, email: string, role: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
+  async addTeamMemberRole(team: string, email: string, role: string) {
+    return await this._request(
       HTTPMethod.POST, `/teams/${team}/role`,
-      success,
-      error,
       {
         email: email,
         role: role,
@@ -568,11 +568,9 @@ export class API {
   /**
    * Remove a role from a member of a given team.
    */
-  revokeTeamMemberRole(team: string, email: string, role: string, success: Callback.Success, error: Callback.Error) {
-    this._request(
+  async revokeTeamMemberRole(team: string, email: string, role: string) {
+    return await this._request(
       HTTPMethod.DELETE, `/teams/${team}/role`,
-      success,
-      error,
       {
         email: email,
         role: role,
@@ -583,15 +581,13 @@ export class API {
   /**
    * Creates a new customer support issue.
    */
-  createSupportIssue(description: string, success: Callback.SupportIssue, error: Callback.Error, jobId: string) {
+  async createSupportIssue(description: string, jobId: string) {
     if (jobId === undefined) {
       jobId = null;
     }
 
-    this._request(
+    return await this._request(
       HTTPMethod.POST, '/support/issue',
-      success,
-      error,
       {
         description: description,
         job: jobId,


### PR DESCRIPTION
Opening this up for an initial review some of the functions still need testing though.

Async example:
```
async function getToken(email:string, pass: string) {
  let response = await api.getToken(email, pass)
    .catch((err: Response.Message) => {
      console.log(err)
    }) as Response.GetToken;
  console.log(response)
}
```
`response` yields to Response.GetToken and `err` yields to response.Message

One of the problems I came across was typecasting the response, which is why some functions have an accept and error function passed to `.then`. I don't think this is that big of a problem so this can probably get resolved in future enhancement.

For the most part the switch from callbacks to async is pretty straightforward but the poll smartslice job methods still need further testing so I wouldn't view those as the finished product yet